### PR TITLE
Feat, Design

### DIFF
--- a/src/Project/Challenge/DetailChallenge.css
+++ b/src/Project/Challenge/DetailChallenge.css
@@ -548,7 +548,6 @@ cursor: pointer;
 }
 
 .blank_bottom_place {
-  margin-top: 225px;
   margin-bottom: 150px;
   float: left;
   height: 100px;

--- a/src/Project/Challenge/DetailChallenge.js
+++ b/src/Project/Challenge/DetailChallenge.js
@@ -3,12 +3,17 @@ import React from "react";
 import { useState, useEffect } from "react";
 
 function DetailChallenge() {
-  var [참여현황변수, set참여현황변수] = useState(0); //  챌린지 참여중이 아니면 0, 챌린지에 참여중이면 1
+  var [참여현황변수, set참여현황변수] = useState(1); //  챌린지 참여중이 아니면 0, 챌린지에 참여중이면 1
   var [오늘인증했나변수, set오늘인증했나변수] = useState(0); // 인증했으면 1, 인증 안했으면 0  이 항목은 '참여현황변수'가 1일 경우에만 유효합니다.
 
   var 챌린지시작일변수 = new Date("3 2, 2023, 0:00:00");
   var 챌린지마지막일변수 = new Date("6 31, 2023, 0:00:00");
   var bonin = 0;
+  const [saveReply, setSaveReply] = useState("");
+
+  const saveUserReply = (event) => {
+    setSaveReply(event.target.value);
+  };
   ///////////////////////////////////////////////////////////////// 여기 부터 타이머 만드는데 관련 된 요소 /////////////////////////////////////////////////////////////
 
   const [time, setTime] = useState(new Date()); // 현재 시간 변수는 time 입니다. 해당 값은 밀리초 (ms) 형태로 표기 됩니다. ex "1678198855933"
@@ -29,6 +34,10 @@ function DetailChallenge() {
   var tomorrow1 = new Date(year2, month2, day2 - 1);
 
   var gap = tomorrow - today; // 챌린지 시작일 변수와 현재 날짜의 차를 구합니다.
+  var gap2 = 챌린지시작일변수 - today;
+
+  var day3 = Math.floor(gap2 / (1000 * 60 * 60 * 24));
+
   var zero = ["", "", ""];
   // var day = Math.ceil(gap / (1000 * 60 * 60 * 24))-1; // 값은 86,400,000 으로 해당 값을 밀리초에서 날짜 값으로 바꿔줍니다.  ex "19423"  이 값을 1970.01.01 에 더해주는식으로
   var hour = Math.ceil((gap % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
@@ -101,8 +110,12 @@ function DetailChallenge() {
               <>
                 <div className="state-box-PartInChallenge">
                   참여 중인 챌린지
-                </div>{" "}
-                <div className="state-box-Challenge">진행중</div>
+                </div>
+                {started === 1 ? (
+                  <div className="state-box-Challenge">진행중</div>
+                ) : (
+                  <div className="state-box-Challenge2">진행예정</div>
+                )}
               </>
             ) : started === 1 ? (
               <div className="state-box-Challenge">진행중</div>
@@ -130,32 +143,41 @@ function DetailChallenge() {
                   <div className="box-Today-challenge3">
                     오늘의 챌린지 인증 완료
                   </div> // 인증을 했다면 인증완료 출력, 안했다면 : 밑의 div 인증하기 출력
-                ) : (
+                ) : started === 1 ? (
                   <div
                     className="box-Today-challenge"
                     onClick={() => {
-                      alert("오늘의 챌린지 인증 완료!");
-                      set오늘인증했나변수(1); // 🚩인증 창을 띄우고 인증이 완료되면 되게 다시 수정해야 합니다. 추가로 변수같은걸 만들어서 db에 전송하면 끝🚩
+                      document
+                        .querySelector('.reply-inputform-textbox[type="text"]')
+                        .focus();
+
+                      // 🚩인증 창을 띄우고 인증이 완료되면 되게 다시 수정해야 합니다. 추가로 변수같은걸 만들어서 db에 전송하면 끝🚩
                       // 근데 이 변수를 날짜마다 초기화 해주는 기능이 필요합니다
                     }}
                   >
                     <div className="box-Text">오늘의 챌린지 인증하기</div>
                     <div className="until-time">{final_time}</div>
                   </div>
+                ) : (
+                  <div
+                    className="box-Today-challenge"
+                    onClick={() => {
+                      alert("챌린지 시작일이 아닙니다.");
+                    }}
+                  >
+                    <div className="box-Text">챌린지 시작까지</div>
+                    <div className="until-time">{day3 + 1}일</div>
+                  </div>
                 )
+              ) : started === 1 ? (
+                <div className="box-Today-challenge4">마감된 챌린지입니다</div>
               ) : (
-                //  (closed === 1) ? // 🧡 챌린지에 참여하지 않은사람들입니다. 챌린지 시작 날짜가 지났는지 확인합니다.
-                //  <div className="box-Today-challenge4">마감된 챌린지입니다</div> :  // 지났다면 마감되었다고 알려줍니다.
                 <>
                   <div
                     className="box-Today-challenge2"
                     onClick={() => {
-                      if (started === 1) {
-                        alert("챌린지에 참여하였습니다!"); // 🚩맘에 드는 폼으로 수정해야 합니다 🚩
-                        set참여현황변수(1);
-                      } else {
-                        alert("시작일이 아닙니다"); //🚩맘에 드는 폼으로 수정해야 합니다 🚩
-                      }
+                      alert("챌린지에 참여하였습니다!"); // 🚩맘에 드는 폼으로 수정해야 합니다 🚩
+                      set참여현황변수(1);
                     }}
                   >
                     함께 하기
@@ -167,7 +189,16 @@ function DetailChallenge() {
         </div>
         {started === 0 ? (
           <>
-            <div className="blank_bottom_place">진행 예정인 챌린지입니다.</div>
+            {closed === 1 ? (
+              <div className="blank_bottom_place">
+                모집 마감된 챌린지입니다.
+              </div>
+            ) : (
+              <div className="blank_bottom_place">
+                진행 예정인 챌린지입니다.
+              </div>
+            )}
+
             <img
               className="image-explain-detail"
               alt="챌린지설명"
@@ -190,8 +221,43 @@ function DetailChallenge() {
                         type="text"
                         className="reply-inputform-textbox"
                         placeholder="챌린지 인증 댓글 입력"
+                        value={saveReply}
+                        onChange={saveUserReply}
                       />
-                      <div className="reply-inputform-button">등록</div>
+                      {closed === 1 ? (
+                        <div
+                          className="reply-inputform-button"
+                          onClick={() => {
+                            alert("마감된 챌린지 입니다.");
+                          }}
+                        >
+                          등록
+                        </div>
+                      ) : 오늘인증했나변수 === 1 ? (
+                        <div
+                          className="reply-inputform-button"
+                          onClick={() => {
+                            alert("오늘은 이미 인증했습니다.");
+                          }}
+                        >
+                          등록
+                        </div>
+                      ) : (
+                        <div
+                          className="reply-inputform-button"
+                          onClick={() => {
+                            if (saveReply === "") {
+                              alert("글을 작성해주세요.");
+                            } else {
+                              set오늘인증했나변수(1);
+                              alert("인증되었습니다.");
+                              //리다이렉트
+                            }
+                          }}
+                        >
+                          등록
+                        </div>
+                      )}
                     </div>
                     <div className="reply-list">
                       <div className="reply-obj">

--- a/src/Project/Challenge/DetailChallenge.js
+++ b/src/Project/Challenge/DetailChallenge.js
@@ -207,108 +207,109 @@ function DetailChallenge() {
               }
             ></img>
           </>
-        ) : null}
-        <div className="bottom-place">
-          {
-            // 나의 챌린지 참여 현황은 챌린지에 참여 중일때만 표시되도록 하였습니다.
-            참여현황변수 === 1 ? (
-              <>
-                <section id="check">
-                  <div className="reply-box">
-                    <div className="challenge-certify">챌린지 인증</div>
-                    <div className="reply-inputform">
-                      <input
-                        type="text"
-                        className="reply-inputform-textbox"
-                        placeholder="챌린지 인증 댓글 입력"
-                        value={saveReply}
-                        onChange={saveUserReply}
-                      />
-                      {closed === 1 ? (
-                        <div
-                          className="reply-inputform-button"
-                          onClick={() => {
-                            alert("마감된 챌린지 입니다.");
-                          }}
-                        >
-                          등록
+        ) : (
+          <div className="bottom-place">
+            {
+              // 나의 챌린지 참여 현황은 챌린지에 참여 중일때만 표시되도록 하였습니다.
+              참여현황변수 === 1 ? (
+                <>
+                  <section id="check">
+                    <div className="reply-box">
+                      <div className="challenge-certify">챌린지 인증</div>
+                      <div className="reply-inputform">
+                        <input
+                          type="text"
+                          className="reply-inputform-textbox"
+                          placeholder="챌린지 인증 댓글 입력"
+                          value={saveReply}
+                          onChange={saveUserReply}
+                        />
+                        {closed === 1 ? (
+                          <div
+                            className="reply-inputform-button"
+                            onClick={() => {
+                              alert("마감된 챌린지 입니다.");
+                            }}
+                          >
+                            등록
+                          </div>
+                        ) : 오늘인증했나변수 === 1 ? (
+                          <div
+                            className="reply-inputform-button"
+                            onClick={() => {
+                              alert("오늘은 이미 인증했습니다.");
+                            }}
+                          >
+                            등록
+                          </div>
+                        ) : (
+                          <div
+                            className="reply-inputform-button"
+                            onClick={() => {
+                              if (saveReply === "") {
+                                alert("글을 작성해주세요.");
+                              } else {
+                                set오늘인증했나변수(1);
+                                alert("인증되었습니다.");
+                                //리다이렉트
+                              }
+                            }}
+                          >
+                            등록
+                          </div>
+                        )}
+                      </div>
+                      <div className="reply-list">
+                        <div className="reply-obj">
+                          <div className="reply-objleft">닉네임01</div>
+                          <div className="reply-objcontent">
+                            2023년 03월 10일 오늘도 인증 완료!
+                          </div>
+                          <div className="reply-objdate">1시간 전</div>
+                          {bonin === 0 ? ( // 댓글을 쓴 사람과 본인 id가 일치하면
+                            <div className="reply-objchange">수정</div>
+                          ) : null}
                         </div>
-                      ) : 오늘인증했나변수 === 1 ? (
-                        <div
-                          className="reply-inputform-button"
-                          onClick={() => {
-                            alert("오늘은 이미 인증했습니다.");
-                          }}
-                        >
-                          등록
+                        <div className="reply-obj">
+                          <div className="reply-objleft">닉네임02</div>
+                          <div className="reply-objcontent">
+                            인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글
+                          </div>
+                          <div className="reply-objdate">2023-03-09</div>
+                          {bonin === 0 ? ( // 댓글을 쓴 사람과 본인 id가 일치하면
+                            <div className="reply-objchange">수정</div>
+                          ) : null}
                         </div>
-                      ) : (
-                        <div
-                          className="reply-inputform-button"
-                          onClick={() => {
-                            if (saveReply === "") {
-                              alert("글을 작성해주세요.");
-                            } else {
-                              set오늘인증했나변수(1);
-                              alert("인증되었습니다.");
-                              //리다이렉트
-                            }
-                          }}
-                        >
-                          등록
+                        <div className="reply-obj">
+                          <div className="reply-objleft">이름은몇글자까지</div>
+                          <div className="reply-objcontent">
+                            인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글
+                          </div>
+                          <div className="reply-objdate">2023-03-09</div>
+                          {bonin === 1 ? ( // 댓글을 쓴 사람과 본인 id가 일치하면
+                            <div className="reply-objchange">수정</div>
+                          ) : null}
                         </div>
-                      )}
+                        <div className="reply-moreContent">더보기</div>
+                      </div>
                     </div>
-                    <div className="reply-list">
-                      <div className="reply-obj">
-                        <div className="reply-objleft">닉네임01</div>
-                        <div className="reply-objcontent">
-                          2023년 03월 10일 오늘도 인증 완료!
-                        </div>
-                        <div className="reply-objdate">1시간 전</div>
-                        {bonin === 0 ? ( // 댓글을 쓴 사람과 본인 id가 일치하면
-                          <div className="reply-objchange">수정</div>
-                        ) : null}
-                      </div>
-                      <div className="reply-obj">
-                        <div className="reply-objleft">닉네임02</div>
-                        <div className="reply-objcontent">
-                          인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글
-                        </div>
-                        <div className="reply-objdate">2023-03-09</div>
-                        {bonin === 0 ? ( // 댓글을 쓴 사람과 본인 id가 일치하면
-                          <div className="reply-objchange">수정</div>
-                        ) : null}
-                      </div>
-                      <div className="reply-obj">
-                        <div className="reply-objleft">이름은몇글자까지</div>
-                        <div className="reply-objcontent">
-                          인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글인증글
-                        </div>
-                        <div className="reply-objdate">2023-03-09</div>
-                        {bonin === 1 ? ( // 댓글을 쓴 사람과 본인 id가 일치하면
-                          <div className="reply-objchange">수정</div>
-                        ) : null}
-                      </div>
-                      <div className="reply-moreContent">더보기</div>
-                    </div>
-                  </div>
-                </section>
+                  </section>
 
-                <div className="table-big">
-                  <img
-                    className="detail-image"
-                    alt=""
-                    src={
-                      process.env.PUBLIC_URL +
-                      "/image/detailChallenge/detail9.png"
-                    }
-                  ></img>
-                </div>
-              </>
-            ) : null
-          }
-        </div>
+                  <div className="table-big">
+                    <img
+                      className="detail-image"
+                      alt=""
+                      src={
+                        process.env.PUBLIC_URL +
+                        "/image/detailChallenge/detail9.png"
+                      }
+                    ></img>
+                  </div>
+                </>
+              ) : null
+            }
+          </div>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
기본적인 로직 변경 및 디자인 살짝 수정했습니다..

detailChallenge 하단여백 부분 
현재는  사진 자체에 여백이 있어서 그대로 적용했는데

영 아니면 수정 해야함

//

챌린지 시작일이 3월 1일 이라 가정
챌린지 마지막날이 6월 1일 이라 가정.

현재 시간부터 ~ 3월 1일 까지는 '챌린지 신청'을 할 수 있다.// db 현재 챌린지  참여여부 변수 필요. 해당 변수는 챌린지 당 1개를 가지면 됨.
만약 참여 하지 않은 챌린지인데 현재 시간이 3월 1일 (당일 포함) 이라면, 해당 챌린지는 참여 모집이 마감되어 마감되었다는 표시만 나온다.
참여했거나 참여하지 않은 경우에 상관없이 현재 시간이 6월 1이후(당일 포함)라면, 해당 챌린지는 챌린지 기간이 마감되어 마감되었다는 표시만 나온다.

챌린지 시작 전에 챌린지 참여를 했다면,
여기서 다시 
현재 시간이 챌린지 시작일을 지났는지 확인한다.
만약 지나지 않았다면 챌린지 시작일까지 며칠이 남았는지 표시해주고 (X일) 버튼을 눌러도 시작일이 지나지 않았다는 경고문이 나온다.
만약 시작일이 지났다면, 그날 챌린지에 참여를 하였는지 여부를 검사한다.// db 현재 챌린지의 오늘 날짜 기준 인증 변수 필요. 해당 변수는 챌린지의 날짜당 1개씩 가져야한다.
만약 해당 변수를 포함하지 않는다면 db에서 해당 날짜의 댓글 여부를 조사하여 판단하도록 한다.
 
참여했다면 참여한 상태의 화면을 보여주고 아무것도 클릭불가
참여하지 않았다면 출석 버튼이 활성화 되며
참여할 수 있는 상태가 되어 내일 00시까지 남은 시간을 초단위로 표시해준다. 
해당 버튼을 누르면 챌린지 인증 댓글 창으로 focus 되며 등록(아무것도 없으면 불가)을 누르면 해당일 출석이 완료된다.

마찬가지로 오늘 이미 등록을 했다면 이미 출석했다는 경고창을 띄운다.
또한 챌린지 기간이 끝났을 경우 등록을 하려고 해도 마감되었다는 경고창을 띄운다.